### PR TITLE
[FIX] 비활성화 된 expoToken 삭제 api  DeviceId 헤더로 이동 #344"

### DIFF
--- a/src/main/java/FIS/iLUVit/controller/ExpoTokenController.java
+++ b/src/main/java/FIS/iLUVit/controller/ExpoTokenController.java
@@ -69,10 +69,9 @@ public class ExpoTokenController {
      * 비활성화 된 expoToken을 삭제한다
      */
     @DeleteMapping("deactivate")
-    public void deleteDeactivatedToken(@RequestBody @Valid ExpoTokenDeviceIdDto expoTokenDeviceIdDto){
-        expoTokenService.deleteDeactivatedExpoToken(expoTokenDeviceIdDto);
+    public void deleteDeactivatedToken(HttpServletRequest request){
+        String deviceId = request.getHeader("DeviceId");
+        expoTokenService.deleteDeactivatedExpoToken(deviceId);
     }
-
-
 
 }

--- a/src/main/java/FIS/iLUVit/service/ExpoTokenService.java
+++ b/src/main/java/FIS/iLUVit/service/ExpoTokenService.java
@@ -68,8 +68,7 @@ public class ExpoTokenService {
     /**
      * 비활성화 된 expoToken을 삭제한다
      */
-    public void deleteDeactivatedExpoToken(ExpoTokenDeviceIdDto expoTokenDeviceIdDto){
-        String deviceId = expoTokenDeviceIdDto.getDeviceId();
+    public void deleteDeactivatedExpoToken(String deviceId){
         expoTokenRepository.deleteByDeviceIdAndActive(deviceId, false);
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- Related to: #344 

## 📌 설명
<!-- pr에 대한 설명을 적어주세요 -->
- react native 에서 delete method에 request body를 보내지 못 하는 문제로 인해 device Id를 request header로 넘겨주는 것으로 변경하였습니다

